### PR TITLE
Ensure Sankey links fill node height

### DIFF
--- a/d3.sankey.js
+++ b/d3.sankey.js
@@ -59,12 +59,21 @@ d3.sankey = function() {
                 xi = d3.interpolateNumber(x0, x1),
                 x2 = xi(curvature),
                 x3 = xi(1 - curvature),
-                y0 = d.source.y + d.sy + d.dy / 2,
-                y1 = d.target.y + d.ty + d.dy / 2;
-            return "M" + x0 + "," + y0
-                + "C" + x2 + "," + y0
-                + " " + x3 + "," + y1
-                + " " + x1 + "," + y1;
+                y0 = d.source.y + d.sy + d.dySource / 2,
+                y1 = d.target.y + d.ty + d.dyTarget / 2,
+                y0a = y0 - d.dySource / 2,
+                y0b = y0 + d.dySource / 2,
+                y1a = y1 - d.dyTarget / 2,
+                y1b = y1 + d.dyTarget / 2;
+            return "M" + x0 + "," + y0a
+                + "C" + x2 + "," + y0a
+                + " " + x3 + "," + y1a
+                + " " + x1 + "," + y1a
+                + "L" + x1 + "," + y1b
+                + "C" + x3 + "," + y1b
+                + " " + x2 + "," + y0b
+                + " " + x0 + "," + y0b
+                + "Z";
         }
 
         link.curvature = function(_) {
@@ -265,15 +274,19 @@ d3.sankey = function() {
             var sourceSum = node.sourceValue || d3.sum(node.sourceLinks, value);
             var targetSum = node.targetValue || d3.sum(node.targetLinks, value);
             node.sourceLinks.forEach(function(link) {
-                link.dy = node.dy * (link.value / sourceSum);
+                link.dySource = node.dy * (link.value / sourceSum);
                 link.sy = sy;
-                sy += link.dy;
+                sy += link.dySource;
             });
             node.targetLinks.forEach(function(link) {
-                link.dy = node.dy * (link.value / targetSum);
+                link.dyTarget = node.dy * (link.value / targetSum);
                 link.ty = ty;
-                ty += link.dy;
+                ty += link.dyTarget;
             });
+        });
+
+        links.forEach(function(link) {
+            link.dy = (link.dySource + link.dyTarget) / 2;
         });
 
         function ascendingSourceDepth(a, b) {

--- a/script.js
+++ b/script.js
@@ -558,23 +558,21 @@ function updateSankey(slider1Value, slider2Value, colourScheme, align, toggleSwi
             .enter().append('path')
             .attr('class', 'link')
             .attr('d', path)
-            .style('stroke-width', d => Math.max(1, d.dy))
-            .style('fill', 'none')
-            .style('stroke-opacity', 0)
+            .style('fill-opacity', 0)
+            .style('stroke', 'none')
             .sort((a, b) => b.dy - a.dy)
             .on('mouseover', function() {
-                d3.select(this).style('stroke-opacity', 0.7);
+                d3.select(this).style('fill-opacity', 0.7);
             })
             .on('mouseout', function() {
-                d3.select(this).style('stroke-opacity', 0.3);
+                d3.select(this).style('fill-opacity', 0.3);
             });
 
 // add transition to links
         link.transition()
             .duration(100) // set the duration of the transition
             .delay((d, i) => i * 20) // set a delay for each link based on its index
-            .style('stroke-opacity', 0.3) // animate the stroke opacity from 0.18 to 0.8
-            .style('stroke-width', d => Math.max(1, d.dy * 0.8)); // animate the stroke width based on the link's thickness
+            .style('fill-opacity', 0.3); // animate the fill opacity
 
         // append text on mouse hover
         link.append('title')
@@ -686,7 +684,7 @@ function updateSankey(slider1Value, slider2Value, colourScheme, align, toggleSwi
             .style('font-size', '10px', 'bold');
 
         // add gradient to links
-        link.style('stroke', (d, i) => {
+        link.style('fill', (d, i) => {
             // make unique gradient ids
             const gradientID = `gradient${i}`;
 
@@ -726,14 +724,14 @@ function updateSankey(slider1Value, slider2Value, colourScheme, align, toggleSwi
             d.targetLinks.forEach(link => {
                 svg.selectAll('.link')
                     .filter(l => l.source === link.source && l.target === link.target)
-                    .style('stroke-opacity', 0.7);
+                    .style('fill-opacity', 0.7);
             });
 
             // Highlight outgoing links
             d.sourceLinks.forEach(link => {
                 svg.selectAll('.link')
                     .filter(l => l.source === link.source && l.target === link.target)
-                    .style('stroke-opacity', 0.7);
+                    .style('fill-opacity', 0.7);
             });
         }
 
@@ -744,7 +742,7 @@ function updateSankey(slider1Value, slider2Value, colourScheme, align, toggleSwi
                 d.targetLinks.forEach(link => {
                     svg.selectAll('.link')
                         .filter(l => l.source === link.source && l.target === link.target)
-                        .style('stroke-opacity', strokeOpacity);
+                        .style('fill-opacity', strokeOpacity);
                 });
             }
 
@@ -753,7 +751,7 @@ function updateSankey(slider1Value, slider2Value, colourScheme, align, toggleSwi
                 d.sourceLinks.forEach(link => {
                     svg.selectAll('.link')
                         .filter(l => l.source === link.source && l.target === link.target)
-                        .style('stroke-opacity', strokeOpacity);
+                        .style('fill-opacity', strokeOpacity);
                 });
             }
 


### PR DESCRIPTION
## Summary
- compute per-node totals for incoming and outgoing links
- scale link thickness by side so incoming and outgoing links fill the node box

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685411ae048483278308cc1f2edb64cf